### PR TITLE
Correspondence api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,12 @@ Style/SymbolArray:
 
 Style/SpecialGlobalVars:
   Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,3 +18,5 @@
   - Update rubocop version
 2.2.2 September, 2018
   - Update docs
+2.3.0 April, 2019
+  - Add Correspondence model

--- a/chargehound.gemspec
+++ b/chargehound.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Automatically fight disputes'
   spec.license     = 'MIT'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'minitest', '~> 5.8'
   spec.add_development_dependency 'rake', '~> 11.1'
   spec.add_development_dependency 'rubocop', '~> 0.49'

--- a/chargehound.gemspec
+++ b/chargehound.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Automatically fight disputes'
   spec.license     = 'MIT'
 
-  spec.add_development_dependency 'bundler', '~> 2'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.8'
   spec.add_development_dependency 'rake', '~> 11.1'
   spec.add_development_dependency 'rubocop', '~> 0.49'

--- a/lib/chargehound/api_request.rb
+++ b/lib/chargehound/api_request.rb
@@ -39,10 +39,7 @@ module Chargehound
     end
 
     def build_http_opts
-      {
-        use_ssl: true,
-        read_timeout: Chargehound.timeout
-      }
+      { use_ssl: true, read_timeout: Chargehound.timeout }
     end
 
     def build_headers(body)
@@ -100,7 +97,12 @@ module Chargehound
     def convert(dict)
       case dict['object']
       when 'dispute'
-        dict['products'].map! { |item| Product.new(item) }
+        dict['products'] = dict.fetch('products', []).map { |item|
+          Product.new(item)
+        }
+        dict['correspondence'] = dict.fetch('correspondence', []).map { |item|
+          Correspondence.new(item)
+        }
         Dispute.new(dict)
       when 'list'
         dict['data'].map! { |item| convert item }

--- a/lib/chargehound/api_request.rb
+++ b/lib/chargehound/api_request.rb
@@ -101,7 +101,7 @@ module Chargehound
           Product.new(item)
         }
         dict['correspondence'] = dict.fetch('correspondence', []).map { |item|
-          Correspondence.new(item)
+          CorrespondenceItem.new(item)
         }
         Dispute.new(dict)
       when 'list'

--- a/lib/chargehound/models.rb
+++ b/lib/chargehound/models.rb
@@ -40,6 +40,9 @@ module Chargehound
   class Product < ChargehoundObject
   end
 
+  class Correspondence < ChargehoundObject
+  end
+
   # Expose response properties via this struct on response objects
   HTTPResponse = Struct.new(:status)
 end

--- a/lib/chargehound/models.rb
+++ b/lib/chargehound/models.rb
@@ -40,7 +40,7 @@ module Chargehound
   class Product < ChargehoundObject
   end
 
-  class Correspondence < ChargehoundObject
+  class CorrespondenceItem < ChargehoundObject
   end
 
   # Expose response properties via this struct on response objects

--- a/lib/chargehound/version.rb
+++ b/lib/chargehound/version.rb
@@ -1,3 +1,3 @@
 module Chargehound
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.3.0'.freeze
 end

--- a/test/disputes_test.rb
+++ b/test/disputes_test.rb
@@ -75,18 +75,60 @@ dispute_with_product_info_response = {
   ]
 }
 
-dispute_response = {
+dispute_with_correspondence_info_update = {
+  fields: {
+    customer_name: 'Susie'
+  },
+  correspondence: [
+    {
+      to: 'customer@example.com',
+      from: 'noreply@example.com',
+      subject: 'Your Order',
+      body: 'Your order was received.',
+      caption: 'Order confirmation email.'
+    }, {
+      to: 'customer@example.com',
+      from: 'noreply@example.com',
+      subject: 'Your Order',
+      body: 'Your order was delivered.',
+      caption: 'Delivery confirmation email.'
+    }
+  ]
+}
+
+dispute_with_correspondence_info_response = {
   id: 'dp_123',
   object: 'dispute',
-  products: []
+  fields: {
+    customer_name: 'Susie'
+  },
+  correspondence: [
+    {
+      to: 'customer@example.com',
+      from: 'noreply@example.com',
+      subject: 'Your Order',
+      body: 'Your order was received.',
+      caption: 'Order confirmation email.'
+    }, {
+      to: 'customer@example.com',
+      from: 'noreply@example.com',
+      subject: 'Your Order',
+      body: 'Your order was delivered.',
+      caption: 'Delivery confirmation email.'
+    }
+  ]
+}
+
+dispute_response = {
+  id: 'dp_123',
+  object: 'dispute'
 }
 
 dispute_list_response = {
   object: 'list',
   data: [{
     id: 'dp_123',
-    object: 'dispute',
-    products: []
+    object: 'dispute'
   }]
 }
 
@@ -145,7 +187,8 @@ describe Chargehound::Disputes do
       data: [{
         id: 'dp_123',
         object: 'dispute',
-        products: []
+        products: [],
+        correspondence: []
       }],
       response: {
         status: '200'
@@ -260,6 +303,33 @@ describe Chargehound::Disputes do
     assert_requested stub
   end
 
+  it 'can submit a dispute with correspondence data' do
+    stub = stub_request(:post, 'https://api.chargehound.com/v1/disputes/dp_123/submit')
+           .with(headers: post_headers,
+                 body: dispute_with_correspondence_info_update.to_json)
+           .to_return(body: dispute_with_correspondence_info_response.to_json,
+                      status: 201)
+
+    Chargehound::Disputes.submit('dp_123',
+                                 dispute_with_correspondence_info_update)
+    assert_requested stub
+  end
+
+  it 'has a model for correspondence data' do
+    stub = stub_request(:post, 'https://api.chargehound.com/v1/disputes/dp_123/submit')
+           .with(headers: post_headers,
+                 body: dispute_with_correspondence_info_update.to_json)
+           .to_return(body: dispute_with_correspondence_info_response.to_json,
+                      status: 201)
+
+    dispute = Chargehound::Disputes.submit(
+      'dp_123', dispute_with_correspondence_info_update
+    )
+
+    assert_instance_of(Chargehound::Correspondence, dispute.correspondence[0])
+    assert_requested stub
+  end
+
   it 'can update a dispute' do
     stub = stub_request(:put, 'https://api.chargehound.com/v1/disputes/dp_123')
            .with(headers: post_headers, body: dispute_update.to_json)
@@ -276,6 +346,17 @@ describe Chargehound::Disputes do
            .to_return(body: dispute_response.to_json)
 
     Chargehound::Disputes.update('dp_123', dispute_with_product_info_update)
+    assert_requested stub
+  end
+
+  it 'can update a dispute with correspondence data' do
+    stub = stub_request(:put, 'https://api.chargehound.com/v1/disputes/dp_123')
+           .with(headers: post_headers,
+                 body: dispute_with_correspondence_info_update.to_json)
+           .to_return(body: dispute_response.to_json)
+
+    Chargehound::Disputes.update('dp_123',
+                                 dispute_with_correspondence_info_update)
     assert_requested stub
   end
 end

--- a/test/disputes_test.rb
+++ b/test/disputes_test.rb
@@ -326,7 +326,8 @@ describe Chargehound::Disputes do
       'dp_123', dispute_with_correspondence_info_update
     )
 
-    assert_instance_of(Chargehound::Correspondence, dispute.correspondence[0])
+    assert_instance_of(Chargehound::CorrespondenceItem,
+                       dispute.correspondence[0])
     assert_requested stub
   end
 


### PR DESCRIPTION
Add a Correspondence model for adapting responses, and tests for using the correspondence API.