### PR TITLE
Security fix. Upgrade rake

### DIFF
--- a/chargehound.gemspec
+++ b/chargehound.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.8'
-  spec.add_development_dependency 'rake', '~> 11.1'
+  spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop', '~> 0.49'
   spec.add_development_dependency 'webmock', '~> 2.3'
 


### PR DESCRIPTION
Upgrade rake to patch a security vulnerability. Because rake is a dev dependency, I don't think we need to publish a new version of the SDK. 