### PR TITLE
Fix [DTSIMIE-7576] Updating ruby and Jruby package version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6']
+        ruby: [ '2.4', '2.5', '2.6', '3.1']
     name: Test Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rvm.yml
+++ b/.github/workflows/rvm.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'jruby-9.2.9.0', 'jruby-head' ]
+        ruby: [ 'jruby' ]
     name: Test Ruby ${{ matrix.ruby }}
     steps:
     - name: Install libraries
       run: sudo apt install haveged
     - uses: actions/checkout@v2
-    - name: Set up RVM
+    - name: Set up RVM Package
       run: |
         curl -sSL https://get.rvm.io | bash
     - name: Set up Ruby
       run: |
         source $HOME/.rvm/scripts/rvm
-        rvm install ${{ matrix.ruby }} --binary
+        rvm install ${{ matrix.ruby }}
         rvm --default use ${{ matrix.ruby }}
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Ruby version : Current 2.6 version is outdated. Latest is above 3.x version.

JRuby version:  we are in 9.2 version for Jruby which is released "October 30 2019" which is outdated while running tests it throws lot of test failures.Latest Version of Jruby is JRuby 9.4.12.0.

JRuby-head is dependency of Jruby which is failing on both older and new versions, most of blogs says its depreciated.